### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "run = python CalC.py"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # MyPersonalProject
  This repo contains all the projects that I've made till now
+[![Run on Repl.it](https://repl.it/badge/github/Radioactive92177/MyPersonalProject)](https://repl.it/github/Radioactive92177/MyPersonalProject)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Raaz92177/MyPersonalProject).